### PR TITLE
:bug: fix unsafe access to empty encoder

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -237,10 +237,6 @@ func (r *Registry) Print() {
 
 	for _, subject := range r.schemas {
 		for _, version := range subject {
-			if version == nil {
-				continue
-			}
-
 			table.SetColumnAlignment([]int{tablewriter.ALIGN_LEFT})
 			table.SetAutoFormatHeaders(true)
 			table.Append([]string{

--- a/registry.go
+++ b/registry.go
@@ -237,6 +237,10 @@ func (r *Registry) Print() {
 
 	for _, subject := range r.schemas {
 		for _, version := range subject {
+			if version == nil {
+				continue
+			}
+
 			table.SetColumnAlignment([]int{tablewriter.ALIGN_LEFT})
 			table.SetAutoFormatHeaders(true)
 			table.Append([]string{

--- a/sync.go
+++ b/sync.go
@@ -153,6 +153,9 @@ func (s *backgroundSync) apply(keyByt []byte, valByt []byte) {
 				})
 
 				if err != nil {
+					s.registry.logger.Error(`schemaregistry.sync`,
+						fmt.Sprintf(`error composing encoder due to: %v`, err))
+					return
 				}
 
 				encoder[value.Version] = e


### PR DESCRIPTION


- [x] schema registry panics when print is called on empty 
- [x] handle error upon composing encoder and avoid appending empty reference to array
